### PR TITLE
fix bytecode generator error with nan constant expressions (0/0)

### DIFF
--- a/lang/ast-const-eval.lua
+++ b/lang/ast-const-eval.lua
@@ -9,7 +9,7 @@ local function dirop_compute(o, a, b)
    if     o == '+' then return a + b
    elseif o == '-' then return a - b
    elseif o == '*' then return a * b
-   elseif o == '/' then return a / b
+   elseif o == '/' then return (a ~= 0 or b ~= 0) and (a / b) or nil
    elseif o == '%' then return a % b
    elseif o == '^' then return a ^ b
    end


### PR DESCRIPTION
otherwise expressions such as 0/0 will fail with "table index is nan".